### PR TITLE
Update tree-base.js

### DIFF
--- a/src/features/tree-base/js/tree-base.js
+++ b/src/features/tree-base/js/tree-base.js
@@ -1075,7 +1075,7 @@
 
           if ( row.treeLevel <= currentLevel ){
             // pop any levels that aren't parents of this level, formatting the aggregation at the same time
-            while ( row.treeLevel <= currentLevel ){
+            while ( row.treeLevel <= currentLevel && parents.length ){
               var lastParent = parents.pop();
               service.finaliseAggregations( lastParent );
               currentLevel--;


### PR DESCRIPTION
Check needed for parents.length...
Otherwise, there are cases where tree nodes do not show up, if a given $$treeLevel was set to -1
